### PR TITLE
feat: Limit front page leaderboard to top 20 warriors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ interface PlayerMap {
 async function getLeaderboardData(): Promise<{ entries: LeaderboardEntry[]; totalPlayers: number }> {
   try {
     const [players, totalPlayers] = await Promise.all([
-      getLeaderboard(100),
+      getLeaderboard(20),
       getPlayerCount(),
     ]);
     return {
@@ -135,7 +135,7 @@ export default async function Home() {
       <section className="mb-12">
         <div className="flex items-baseline justify-between mb-4">
           <h2 className="text-cyan glow-cyan text-sm uppercase tracking-widest">
-            {'// Leaderboard'} {totalPlayers > 100 ? '(Top 100)' : ''}
+            {'// Leaderboard'} {totalPlayers > 20 ? '(Top 20)' : ''}
           </h2>
           {totalPlayers > 0 && (
             <span className="text-dim text-xs">


### PR DESCRIPTION
## Summary

Implements #3

- Reduced leaderboard fetch limit from 100 to 20 in `getLeaderboardData()`
- Updated "(Top N)" label threshold from 100 to 20

## Changes

- `app/page.tsx`: Changed `getLeaderboard(100)` → `getLeaderboard(20)` and `totalPlayers > 100 ? '(Top 100)'` → `totalPlayers > 20 ? '(Top 20)'`

## Quality Checks

- [x] All tests pass (95/95)
- [x] Build succeeds
- [x] No security issues introduced

Generated with [Claude Code](https://claude.com/claude-code)