### PR TITLE
feat: Homepage redesign — hero replay, terminal tabs, featured battles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -185,3 +185,59 @@ tr:hover td {
 .code-overlay-scroll::-webkit-scrollbar-thumb:hover {
   background: var(--dim);
 }
+
+/* Hero replay container */
+.hero-replay-container {
+  position: relative;
+  max-height: 300px;
+  overflow: hidden;
+  border: 1px solid var(--cyan);
+  box-shadow: 0 0 20px rgba(0, 255, 204, 0.15), inset 0 0 60px rgba(0, 0, 0, 0.5);
+}
+
+.hero-replay-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.hero-replay-overlay a {
+  pointer-events: auto;
+}
+
+/* Tab bar styles */
+.tab-bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.tab-button {
+  padding: 8px 16px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: color 0.15s;
+}
+
+.tab-button-active {
+  color: var(--cyan);
+  border-bottom-color: var(--cyan);
+}
+
+.tab-button-inactive {
+  color: var(--dim);
+}
+
+.tab-button-inactive:hover {
+  color: var(--foreground);
+}

--- a/app/how-to-play/page.tsx
+++ b/app/how-to-play/page.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+
+export default function HowToPlay() {
+  return (
+    <div className="min-h-screen p-6 max-w-5xl mx-auto">
+      <header className="mb-8 pt-8">
+        <Link href="/" className="text-cyan hover:underline text-sm">
+          &lt; Back to Home
+        </Link>
+      </header>
+
+      <section className="mb-12">
+        <h1 className="text-cyan glow-cyan text-sm mb-4 uppercase tracking-widest">
+          {'// How to Play'}
+        </h1>
+        <div className="border border-border p-6 text-sm space-y-3 text-dim">
+          <p>
+            <span className="text-green">1.</span> Read the{' '}
+            <Link href="/api/skill" className="text-cyan hover:underline">skill.md</Link>{' '}
+            for full Redcode reference and strategy guide
+          </p>
+          <p>
+            <span className="text-green">2.</span> Register:{' '}
+            <code className="text-foreground">POST /api/register</code>{' '}
+            with your name to get an API key
+          </p>
+          <p>
+            <span className="text-green">3.</span> Upload warrior:{' '}
+            <code className="text-foreground">POST /api/warriors</code>{' '}
+            with your Redcode program
+          </p>
+          <p>
+            <span className="text-green">4.</span> Check leaderboard:{' '}
+            <code className="text-foreground">GET /api/leaderboard</code>{' '}
+            to find opponents
+          </p>
+          <p>
+            <span className="text-green">5.</span> Challenge:{' '}
+            <code className="text-foreground">POST /api/challenge</code>{' '}
+            with a defender_id to battle
+          </p>
+          <p>
+            <span className="text-green">6.</span> Iterate — improve your warrior and climb the ranks!
+          </p>
+        </div>
+      </section>
+
+      <footer className="text-center text-dim text-xs py-8 border-t border-border">
+        <p>MODELWAR v0.1 — ICWS &apos;94 Standard — Core Size 55,440</p>
+        <p className="mt-1">A proving ground for AI agents</p>
+      </footer>
+    </div>
+  );
+}

--- a/components/HeroReplay.tsx
+++ b/components/HeroReplay.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useReducer, useRef, useCallback } from 'react';
+import type { ReplayData } from './replay/types';
+import { reducer, createInitialState } from './replay/replay-logic';
+import CoreCanvas from './replay/CoreCanvas';
+import Link from 'next/link';
+
+const TARGET_SECONDS = 18;
+const TARGET_FRAMES = TARGET_SECONDS * 60;
+const MAX_FRAME_SKIP = 10;
+
+interface HeroReplayProps {
+  battleId: number;
+  roundNumber: number;
+  challengerName: string;
+  defenderName: string;
+  score: string;
+}
+
+export default function HeroReplay({
+  battleId,
+  roundNumber,
+  challengerName,
+  defenderName,
+  score,
+}: HeroReplayProps) {
+  const [state, dispatch] = useReducer(reducer, null, createInitialState);
+  const workerRef = useRef<Worker | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const cyclesPerFrameRef = useRef<number>(100);
+  const frameSkipRef = useRef<number>(1);
+  const frameCountRef = useRef<number>(0);
+  const errorRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      try {
+        const res = await fetch(`/api/battles/${battleId}/replay`);
+        if (!res.ok) {
+          errorRef.current = true;
+          dispatch({ type: 'FETCH_ERROR', message: 'Failed to load' });
+          return;
+        }
+
+        const data: ReplayData = await res.json();
+        if (cancelled) return;
+
+        dispatch({ type: 'FETCH_SUCCESS', maxCycles: data.settings.maxCycles });
+
+        const roundData = data.round_results.find((r) => r.round === roundNumber);
+        if (!roundData) {
+          errorRef.current = true;
+          dispatch({ type: 'FETCH_ERROR', message: 'Round not found' });
+          return;
+        }
+
+        const worker = new Worker(
+          new URL('../workers/replay-worker.ts', import.meta.url)
+        );
+        workerRef.current = worker;
+
+        worker.onmessage = (e: MessageEvent) => {
+          const msg = e.data;
+          if (msg.type === 'initialized') {
+            dispatch({ type: 'INITIALIZED' });
+            worker.postMessage({ type: 'prescan' });
+          } else if (msg.type === 'prescan_done') {
+            const endCycle = msg.endCycle as number;
+            if (endCycle <= TARGET_FRAMES) {
+              cyclesPerFrameRef.current = 1;
+              frameSkipRef.current = Math.min(
+                MAX_FRAME_SKIP,
+                Math.max(1, Math.round(TARGET_FRAMES / endCycle))
+              );
+            } else {
+              cyclesPerFrameRef.current = Math.ceil(endCycle / TARGET_FRAMES);
+              frameSkipRef.current = 1;
+            }
+            dispatch({ type: 'PRESCAN_DONE', endCycle });
+            // Auto-play immediately
+            dispatch({ type: 'PLAY' });
+          } else if (msg.type === 'events') {
+            dispatch({
+              type: 'EVENTS',
+              events: msg.events,
+              cycle: msg.cycle,
+              challengerTasks: msg.challengerTasks,
+              defenderTasks: msg.defenderTasks,
+            });
+          } else if (msg.type === 'round_end') {
+            dispatch({ type: 'ROUND_END', winner: msg.winner, cycle: msg.cycle });
+          } else if (msg.type === 'error') {
+            errorRef.current = true;
+            dispatch({ type: 'INIT_ERROR', message: msg.message });
+          }
+        };
+
+        worker.postMessage({
+          type: 'init',
+          challengerRedcode: data.challenger.redcode,
+          defenderRedcode: data.defender.redcode,
+          seed: roundData.seed,
+          settings: data.settings,
+          roundIndex: roundNumber - 1,
+        });
+      } catch {
+        if (!cancelled) {
+          errorRef.current = true;
+          dispatch({ type: 'FETCH_ERROR', message: 'Failed to load' });
+        }
+      }
+    }
+
+    init();
+
+    return () => {
+      cancelled = true;
+      workerRef.current?.terminate();
+      workerRef.current = null;
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [battleId, roundNumber]);
+
+  // Animation loop
+  useEffect(() => {
+    if (state.status !== 'playing') {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      return;
+    }
+
+    function tick() {
+      if (!workerRef.current) return;
+      frameCountRef.current++;
+      if (frameCountRef.current % frameSkipRef.current === 0) {
+        workerRef.current.postMessage({ type: 'step', count: cyclesPerFrameRef.current });
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [state.status]);
+
+  // Silent failure: render nothing on error or loading
+  if (state.status === 'error') return null;
+  if (state.status === 'loading') {
+    return (
+      <div className="hero-replay-container">
+        <div className="flex items-center justify-center h-48">
+          <p className="text-cyan text-xs tracking-widest">LOADING REPLAY...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hero-replay-container">
+      <CoreCanvas
+        territoryMap={state.territoryMap}
+        activityMap={state.activityMap}
+      />
+      <div className="hero-replay-overlay">
+        <div className="absolute top-2 left-3 text-cyan text-xs">
+          {'// NOW PLAYING: Battle #'}{battleId} — {score}
+        </div>
+        <div className="absolute bottom-2 left-3 text-sm text-foreground">
+          <span className="text-green">{challengerName}</span>
+          <span className="text-dim"> vs </span>
+          <span className="text-magenta">{defenderName}</span>
+        </div>
+        <Link
+          href={`/battles/${battleId}/rounds/${roundNumber}`}
+          className="absolute bottom-2 right-3 text-cyan text-xs hover:underline"
+        >
+          [WATCH FULL BATTLE]
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/HomeTabs.tsx
+++ b/components/HomeTabs.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+
+type Tab = 'rankings' | 'featured' | 'recent';
+
+interface HomeTabsProps {
+  rankingsContent: React.ReactNode;
+  featuredContent: React.ReactNode;
+  recentContent: React.ReactNode;
+}
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'rankings', label: 'RANKINGS' },
+  { key: 'featured', label: 'FEATURED' },
+  { key: 'recent', label: 'RECENT' },
+];
+
+export default function HomeTabs({
+  rankingsContent,
+  featuredContent,
+  recentContent,
+}: HomeTabsProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('rankings');
+
+  return (
+    <div>
+      <div className="tab-bar">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            className={`tab-button ${
+              activeTab === tab.key ? 'tab-button-active glow-cyan' : 'tab-button-inactive'
+            }`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4">
+        <div style={{ display: activeTab === 'rankings' ? 'block' : 'none' }}>
+          {rankingsContent}
+        </div>
+        <div style={{ display: activeTab === 'featured' ? 'block' : 'none' }}>
+          {featuredContent}
+        </div>
+        <div style={{ display: activeTab === 'recent' ? 'block' : 'none' }}>
+          {recentContent}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/__tests__/battle-utils.test.ts
+++ b/lib/__tests__/battle-utils.test.ts
@@ -1,0 +1,56 @@
+import { findDecisiveRound } from '../battle-utils';
+import type { RoundResultRecord } from '../db';
+
+describe('findDecisiveRound', () => {
+  it('returns correct round for standard 3-2 challenger win (rounds 1, 3, 5)', () => {
+    const rounds: RoundResultRecord[] = [
+      { round: 1, winner: 'challenger', seed: 100 },
+      { round: 2, winner: 'defender', seed: 200 },
+      { round: 3, winner: 'challenger', seed: 300 },
+      { round: 4, winner: 'defender', seed: 400 },
+      { round: 5, winner: 'challenger', seed: 500 },
+    ];
+
+    expect(findDecisiveRound(rounds, 3, 2)).toBe(5);
+  });
+
+  it('returns correct round for defender-win 3-2 battle (rounds 2, 3, 4)', () => {
+    const rounds: RoundResultRecord[] = [
+      { round: 1, winner: 'challenger', seed: 100 },
+      { round: 2, winner: 'defender', seed: 200 },
+      { round: 3, winner: 'defender', seed: 300 },
+      { round: 4, winner: 'defender', seed: 400 },
+      { round: 5, winner: 'challenger', seed: 500 },
+    ];
+
+    expect(findDecisiveRound(rounds, 2, 3)).toBe(4);
+  });
+
+  it('returns correct round for early clinch (rounds 1, 2, 3)', () => {
+    const rounds: RoundResultRecord[] = [
+      { round: 1, winner: 'challenger', seed: 100 },
+      { round: 2, winner: 'challenger', seed: 200 },
+      { round: 3, winner: 'challenger', seed: 300 },
+      { round: 4, winner: 'defender', seed: 400 },
+      { round: 5, winner: 'defender', seed: 500 },
+    ];
+
+    expect(findDecisiveRound(rounds, 3, 2)).toBe(3);
+  });
+
+  it('returns 5 as fallback for empty round_results', () => {
+    expect(findDecisiveRound([], 3, 2)).toBe(5);
+  });
+
+  it('handles rounds with ties correctly', () => {
+    const rounds: RoundResultRecord[] = [
+      { round: 1, winner: 'challenger', seed: 100 },
+      { round: 2, winner: 'tie', seed: 200 },
+      { round: 3, winner: 'challenger', seed: 300 },
+      { round: 4, winner: 'tie', seed: 400 },
+      { round: 5, winner: 'challenger', seed: 500 },
+    ];
+
+    expect(findDecisiveRound(rounds, 3, 2)).toBe(5);
+  });
+});

--- a/lib/__tests__/db.test.ts
+++ b/lib/__tests__/db.test.ts
@@ -259,4 +259,17 @@ describe('Battle queries', () => {
       [10]
     );
   });
+
+  it('getFeaturedBattles: returns close battles with redcode ordered by combined ELO', async () => {
+    const battles = [makeBattle({ challenger_wins: 3, defender_wins: 2 })];
+    mockQuery.mockResolvedValueOnce({ rows: battles });
+
+    const result = await db.getFeaturedBattles();
+
+    expect(result).toEqual(battles);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('challenger_wins = 3 AND defender_wins = 2'),
+      [5]
+    );
+  });
 });

--- a/lib/battle-utils.ts
+++ b/lib/battle-utils.ts
@@ -1,0 +1,17 @@
+import type { RoundResultRecord } from './db';
+
+export function findDecisiveRound(
+  roundResults: RoundResultRecord[],
+  challengerWins: number,
+  defenderWins: number
+): number {
+  const overallWinner = challengerWins > defenderWins ? 'challenger' : 'defender';
+  let winCount = 0;
+  for (const round of roundResults) {
+    if (round.winner === overallWinner) {
+      winCount++;
+      if (winCount === 3) return round.round;
+    }
+  }
+  return roundResults[roundResults.length - 1]?.round ?? 5;
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -235,3 +235,16 @@ export async function getRecentBattles(limit = 10): Promise<Battle[]> {
     [limit]
   );
 }
+
+export async function getFeaturedBattles(limit = 5): Promise<Battle[]> {
+  return query<Battle>(
+    `SELECT * FROM battles
+     WHERE ((challenger_wins = 3 AND defender_wins = 2)
+        OR (challenger_wins = 2 AND defender_wins = 3))
+       AND challenger_redcode IS NOT NULL
+       AND defender_redcode IS NOT NULL
+     ORDER BY (challenger_elo_before + defender_elo_before) DESC
+     LIMIT $1`,
+    [limit]
+  );
+}


### PR DESCRIPTION
## Summary

Implements #20

- Surfaces quality battle replays on the homepage with an auto-playing hero section
- Reorganizes content with tmux-style tabs (RANKINGS / FEATURED / RECENT) to reduce scrolling
- Adds featured battles query to surface close 3-2 battles between top-rated players
- Moves "How to Play" content to its own page at `/how-to-play`

## Changes

### New files
- `components/HeroReplay.tsx` — auto-playing hero replay client component (attract mode)
- `components/HomeTabs.tsx` — tmux-style tab bar client component
- `lib/battle-utils.ts` — `findDecisiveRound` utility function
- `lib/__tests__/battle-utils.test.ts` — tests for battle-utils
- `app/how-to-play/page.tsx` — relocated how-to-play content

### Modified files
- `lib/db.ts` — add `getFeaturedBattles` query (3-2 battles, sorted by combined ELO)
- `lib/__tests__/db.test.ts` — add test for `getFeaturedBattles`
- `app/page.tsx` — hero replay section, tabs, featured battles table, header link update
- `app/globals.css` — hero container, tab bar, and overlay styles

## Test Coverage

- All 178 tests pass
- Coverage: 94.22% statements, 95.23% branches, 96.29% functions, 94.19% lines
- New tests for `findDecisiveRound` (5 test cases) and `getFeaturedBattles` query

## Quality Checks

- [x] All tests pass
- [x] Build succeeds
- [x] No security issues introduced
- [x] TypeScript checks pass
- [x] ESLint passes

Generated with [Claude Code](https://claude.com/claude-code) using Agent Teams